### PR TITLE
add olddefconfig to use defaults for new kernel config options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ WORKDIR /linux
 ENV PKGVERSION 1terra
 
 RUN /wireguard/contrib/kernel-tree/create-patch.sh | patch -p1
+RUN make olddefconfig
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" KDEB_PKGVERSION=$PKGVERSION INSTALL_MOD_STRIP=1 bindeb-pkg
 
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all: buildkit
+
+buildkit:
+	@buildctl build --frontend=dockerfile.v0 --frontend-opt filename=Dockerfile --local context=. --local dockerfile=. --progress plain --exporter=local --exporter-opt output=./""
+
+.PHONY: buildkit


### PR DESCRIPTION
This adds a Makefile for easier use and `olddefconfig` to automatically accept new kernel config defaults.